### PR TITLE
Make request::body an async host function.

### DIFF
--- a/crates/functions/src/lib.rs
+++ b/crates/functions/src/lib.rs
@@ -51,7 +51,7 @@ impl Request {
     }
 
     /// Gets the body of the HTTP request.
-    pub fn body(&self) -> Vec<u8> {
+    pub fn body(&self) -> Result<Vec<u8>, String> {
         functions::request_body(&self.0)
     }
 }

--- a/crates/runtime/witx/functions.witx
+++ b/crates/runtime/witx/functions.witx
@@ -12,7 +12,7 @@ resource request {
     header: function(name: string) -> option<string>
     cookie: function(name: string) -> option<string>
     param: function(name: string) -> option<string>
-    body: function() -> list<u8>
+    body: function() -> expected<list<u8>, string>
 }
 
 resource response {


### PR DESCRIPTION
This PR makes the `request::body` host function async.

It moves the request to the host where it can be safely captured between await
points in `request_body`.